### PR TITLE
Add supply-chain hardened .npmrc (PER-8396)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+audit-level=high
+engine-strict=true
+legacy-peer-deps=false


### PR DESCRIPTION
## Supply-chain hardening: add `.npmrc`

Flagged by the weekly supply-chain `.npmrc` audit ([PER-8396](https://browserstack.atlassian.net/browse/PER-8396), parent [SC-12282](https://browserstack.atlassian.net/browse/SC-12282)) with status `missing_file`.

Adds an `.npmrc` with the required hardening directives: `ignore-scripts`, `strict-ssl`, `save-exact`, `audit-level=high`, `engine-strict`, `legacy-peer-deps=false`. Public repo, so `access=restricted` is intentionally omitted (private-repo only).

> ⚠️ Reviewers: confirm CI `npm install` still passes — `ignore-scripts`/`engine-strict`/`legacy-peer-deps` can change install behavior.

Ref: [Supply Chain Security Enhancements Tech Spec](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec)

[PER-8396]: https://browserstack.atlassian.net/browse/PER-8396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-12282]: https://browserstack.atlassian.net/browse/SC-12282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ